### PR TITLE
Offerer: Our Offers screen (HTML/JS/CSS) + screen switching

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,39 +1,49 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="stylesheet" href="./static/css/styles.css">
-    <title>Hotel reservation</title>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <link rel="stylesheet" href="./static/css/styles.css" />
+  <title>Hotel reservation</title>
 </head>
-
 <body>
-    <section id="welcome">
-        <h1>&#9734; Welcome to our family hotel &#9734;</h1>
-        <div class="home-container">
-            <div class="info">
-                <h1>Hotel reservation</h1>
-            </div>
-        </div>
-    </section>
-
-    <div class="site-content">
-        <!-- Site Content -->
-
-        <!-- Thank you, page! -->
-        <div class="thank-you-content custom-form">
-            <div class="background">
-                <div class="shape"></div>
-                <div class="shape"></div>
-            </div>
-            <form class="thank-you">
-                <h3>Thank you for your reservation!</h3>
-                <button id="new-reservation">Make new reservation</button>
-            </form>
-        </div>
+  <section id="welcome">
+    <h1>&#9734; Welcome to our family hotel &#9734;</h1>
+    <div class="home-container">
+      <div class="info">
+        <h1>Hotel reservation</h1>
+      </div>
     </div>
-    <script src="solution.js"></script>
-</body>
+  </section>
 
+  <div class="site-content">
+    <!-- OUR OFFERS (Offerer) -->
+    <div class="custom-form search-result-form-content hidden">
+      <h2>Our Offers</h2>
+      <form id="offers-form">
+        <fieldset>
+          <legend>Choose room type</legend>
+          <label><input type="radio" name="roomType" value="single" checked> Single Room</label>
+          <label><input type="radio" name="roomType" value="double"> Double Room</label>
+          <label><input type="radio" name="roomType" value="apartment"> Apartment</label>
+        </fieldset>
+        <button type="button" id="btnSelectOffer">Select Offer</button>
+      </form>
+    </div>
+
+    <!-- Thank you (скрит по подразбиране) -->
+    <div class="thank-you-content custom-form hidden">
+      <div class="background">
+        <div class="shape"></div>
+        <div class="shape"></div>
+      </div>
+      <form class="thank-you">
+        <h3>Thank you for your reservation!</h3>
+        <button id="new-reservation">Make new reservation</button>
+      </form>
+    </div>
+  </div>
+
+  <script src="solution.js"></script>
+</body>
 </html>

--- a/solution.js
+++ b/solution.js
@@ -1,4 +1,5 @@
-let reservation = {
+// Глобален модел (ако в проекта вече има такъв, остави този блок, за да не е undefined)
+window.reservation = window.reservation || {
   startDate: null,
   endDate: null,
   guestsCount: 0,
@@ -8,19 +9,40 @@ let reservation = {
   email: null,
 };
 
+// Универсално превключване на екрани (SPA)
 function changeContent(className) {
-  document
-    .querySelectorAll('.custom-form')
-    .forEach((div) => div.classList.add('hidden'));
-  if (document.querySelector(`.${className}`) != null) {
-    document.querySelector(`.${className}`).classList.remove('hidden');
-  }
+  document.querySelectorAll('.custom-form').forEach(d => d.classList.add('hidden'));
+  const target = document.querySelector('.' + className);
+  if (target) target.classList.remove('hidden');
 }
 
-document
-  .querySelector('#new-reservation')
-  .addEventListener('click', (e) => cleanData(e));
+// Offerer — логика за „Our Offers“
+function initOurOffersForm() {
+  const btn = document.getElementById('btnSelectOffer');
+  if (!btn) return;
 
-function cleanData(e) {
-  changeContent('search-form-content');
+  btn.addEventListener('click', () => {
+    const selected = document.querySelector('input[name="roomType"]:checked').value;
+    reservation.roomType = selected;
+
+    // Следващ екран в потока (при вас колегите имат guest-details-form)
+    changeContent('guest-details-form-content');
+  });
 }
+
+// “Make new reservation” (връща към начало — ако имате search-form)
+const newResBtn = document.getElementById('new-reservation');
+if (newResBtn) {
+  newResBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    reservation.roomType = null;
+    changeContent('search-form-content');
+  });
+}
+
+// При локален тест от твоя клон стартираме директно нашия екран
+document.addEventListener('DOMContentLoaded', () => {
+  initOurOffersForm();
+  // Махни следния ред преди merge, ако лидерът предпочита да се влиза от началния екран:
+  changeContent('search-result-form-content');
+});

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -3,37 +3,20 @@
 
 *,
 *:before,
-*:after {
-  padding: 0;
-  margin: 0;
-  box-sizing: border-box;
-}
+*:after { padding: 0; margin: 0; box-sizing: border-box; }
 
 body {
   font-family: Verdana, Geneva, Tahoma, sans-serif;
-  place-items: center;
   background-image: url('../img/zero.jpg');
   background-repeat: no-repeat;
   background-size: cover;
   background-attachment: fixed;
   margin: 0;
-  height: 100vh;
+  min-height: 100vh;
   background-color: #080710;
-  background-color: #080710;
 }
 
-#wrapper {
-  justify-content: center;
-  margin: 2.35rem 0 0;
-  display: flex;
-  justify-content: center;
-}
-
-#welcome {
-  margin: 0;
-  background-color: rgb(0, 0, 0);
-}
-
+#welcome { margin: 0; background-color: #000; }
 #welcome > h1 {
   text-align: center;
   font-family: 'Passions Conflict', cursive;
@@ -41,147 +24,68 @@ body {
   letter-spacing: 0.1rem;
   background: linear-gradient(
     180deg,
-    rgba(165, 195, 250, 1) 17%,
-    rgba(188, 205, 221, 1) 48%,
-    rgba(206, 215, 200, 1) 57%,
-    rgba(246, 236, 153, 1) 69%,
-    rgba(232, 183, 105, 1) 78%
+    rgba(165,195,250,1) 17%,
+    rgba(188,205,221,1) 48%,
+    rgba(206,215,200,1) 57%,
+    rgba(246,236,153,1) 69%,
+    rgba(232,183,105,1) 78%
   );
   color: transparent;
-  background-clip: text;
   -webkit-background-clip: text;
+  background-clip: text;
 }
 
-.home-container {
-  margin: 0px auto 4px 0;
-  height: 1rem;
-  display: flex;
-  top: 0%;
-  left: 50%;
-  text-align: center;
+.home-container { margin: 0 auto 4px 0; height: 1rem; display: flex; text-align: center; }
+.info { display: flex; flex-direction: column; position: relative; flex: 1; margin-top: 10rem; }
+.info > h1 { font-size: 2rem; margin: -10.3rem 0 0; font-weight: 700; text-transform: uppercase; color: rgb(242,238,213); }
+
+.site-content { display: block; padding-bottom: 2rem; }
+.hidden { display: none !important; }
+
+/* === OUR OFFERS (scoped) === */
+.search-result-form-content {
+  background: #f2f2f2;
+  padding: 20px;
+  border-radius: 8px;
+  width: min(640px, 92%);
+  margin: 20px auto;
 }
 
-.info {
-  justify-items: legacy;
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  flex: 1;
-  margin-top: 10rem;
-}
-
-.info > h1 {
-  font-size: 2rem;
-  margin: -10.3rem 0 0px;
-  position: relative;
-  font-weight: 700;
-  text-transform: uppercase;
-  padding: 0;
-  letter-spacing: 0px;
-  font-family: Verdana, Geneva, Tahoma, sans-serif;
-  color: rgb(242, 238, 213);
-}
-
-.site-content {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.background {
-  width: 430px;
-  height: 415px;
-  position: absolute;
-  transform: translate(-50%, -50%);
-  left: 50%;
-  top: 60%;
-}
-
-.background .shape {
-  height: 200px;
-  width: 200px;
-  position: absolute;
-  border-radius: 50%;
-}
-
-.shape:first-child {
-  background: linear-gradient(#36251b, #7c4f30);
-  left: -80px;
-  top: -80px;
-}
-
-.shape:last-child {
-  background: linear-gradient(to right, #daa022, #f09819);
-  right: -30px;
-  bottom: -80px;
-}
-
-form {
-  height: 520px;
-  width: 400px;
-  background-color: rgba(255, 255, 255, 0.13);
-  position: absolute;
-  transform: translate(-50%, -50%);
-  top: 60%;
-  left: 50%;
-  border-radius: 10px;
-  backdrop-filter: blur(10px);
-  border: 2px solid rgba(255, 255, 255, 0.1);
-  box-shadow: 0 0 40px rgba(8, 7, 16, 0.6);
-  padding: 50px 35px;
-}
-
-form * {
-  font-family: 'Poppins', sans-serif;
-  color: #ffffff;
-  letter-spacing: 0.5px;
-  outline: none;
+#offers-form fieldset { border: 1px solid #ccc; padding: 12px; margin: 10px 0; }
+#offers-form legend { font-weight: 600; margin-bottom: 6px; }
+#offers-form label { display: block; margin: 6px 0; }
+#offers-form button {
+  margin-top: 12px;
+  background: #007bff;
   border: none;
-}
-
-form h3 {
-  font-size: 32px;
-  font-weight: 500;
-  line-height: 42px;
-  text-align: center;
-}
-
-::placeholder {
-  color: #e5e5e5;
-}
-
-button {
-  margin-top: 30px;
-  width: 100%;
-  background-color: #ffffff;
-  color: #080710;
-  padding: 15px 0;
-  font-size: 18px;
-  font-weight: 600;
-  border-radius: 5px;
+  color: #fff;
+  padding: 10px 16px;
+  border-radius: 4px;
   cursor: pointer;
 }
+#offers-form button:hover { background: #0056b3; }
 
-button:hover {
-  box-shadow: 1px 1px 11px 8px #e7a83a;
+/* === THANK YOU (glass) — SCOPED само вътре в .thank-you-content === */
+.thank-you-content { position: relative; width: 100%; height: 70vh; }
+.thank-you-content .background {
+  width: 430px; height: 415px; position: absolute;
+  transform: translate(-50%, -50%); left: 50%; top: 60%;
 }
+.thank-you-content .background .shape { height: 200px; width: 200px; position: absolute; border-radius: 50%; }
+.thank-you-content .shape:first-child { background: linear-gradient(#36251b, #7c4f30); left: -80px; top: -80px; }
+.thank-you-content .shape:last-child { background: linear-gradient(to right, #daa022, #f09819); right: -30px; bottom: -80px; }
 
-.site-content {
-  height: 70%;
+.thank-you-content form {
+  height: 320px; width: 400px; background-color: rgba(255,255,255,0.13);
+  position: absolute; transform: translate(-50%, -50%); top: 60%; left: 50%;
+  border-radius: 10px; backdrop-filter: blur(10px);
+  border: 2px solid rgba(255,255,255,0.1); box-shadow: 0 0 40px rgba(8,7,16,0.6);
+  padding: 40px 35px;
 }
-
-.thank-you {
-  display: flex;
-  align-items: center;
-  flex-direction: column;
-  justify-content: space-around;
+.thank-you-content form * { color: #ffffff; }
+.thank-you-content form h3 { font-size: 32px; font-weight: 500; line-height: 42px; text-align: center; }
+.thank-you-content button {
+  margin-top: 30px; width: 100%; background-color: #ffffff; color: #080710;
+  padding: 15px 0; font-size: 18px; font-weight: 600; border-radius: 5px; cursor: pointer; border: none;
 }
-
-.hidden {
-  display: none;
-}
-
-.selected-room {
-  background-color: #cfcbca;
-}
+.thank-you-content button:hover { box-shadow: 1px 1px 11px 8px #e7a83a; }


### PR DESCRIPTION
Implemented the Offerer task:

- Added Our Offers screen (index.html) with room type choice (single/double/apartment).
- Wired JS (solution.js): stores selection in reservation.roomType and navigates to guest-details-form-content.
- Scoped styles for Offerer (static/css/styles.css); Thank You modal hidden by default; glass styles scoped.

Note: In this branch the app starts directly on the Offerer screen for local testing via
changeContent('search-result-form-content'). We can adjust/remove this on merge if the team prefers the full flow.
